### PR TITLE
Element activation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 project(adamantine LANGUAGES CXX VERSION 0.1.0)
 

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -2,9 +2,19 @@
 if (ADAMANTINE_ENABLE_CUDA)
   add_executable(adamantine adamantine.cu)
   target_compile_definitions(adamantine PRIVATE ADAMANTINE_HAVE_CUDA)
+  set_target_properties(adamantine PROPERTIES
+      CUDA_SEPARABLE_COMPILATION ON
+      CUDA_STANDARD 17
+      CUDA_STANDARD_REQUIRED ON
+)
 else()
   add_executable(adamantine adamantine.cc)
+
 endif()
+set_target_properties(adamantine PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF)
 DEAL_II_SETUP_TARGET(adamantine)
 target_link_libraries(adamantine Adamantine)
 file(COPY input.info DESTINATION ${CMAKE_BINARY_DIR}/bin)

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,8 @@
-FROM nvidia/cuda:10.2-devel
+FROM nvidia/cuda:11.0-devel
 
 ARG N_PROCS=12
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
       gcc \
       gfortran \
@@ -32,9 +33,9 @@ RUN mkdir -p ${PREFIX} && \
     mkdir build
 
 # Install CMake
-RUN export CMAKE_VERSION=3.17.1 && \
-    export CMAKE_VERSION_SHORT=3.17 && \
-    export CMAKE_SHA256=23dd30da0bacf0e644d82298907b8e03edbc59c4ed40839afdeeb3b86e66bc93 && \
+RUN export CMAKE_VERSION=3.18.3 && \
+    export CMAKE_VERSION_SHORT=3.18 && \
+    export CMAKE_SHA256=eb23bac95873cc0bc3946eed5d1aea6876ac03f7c0dcc6ad3a05462354b08228 && \
     export CMAKE_URL=https://cmake.org/files/v${CMAKE_VERSION_SHORT}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
     export CMAKE_ARCHIVE=${ARCHIVE_DIR}/cmake.tar.gz && \
     export CMAKE_BUILD_DIR=${BUILD_DIR}/cmake && \
@@ -48,16 +49,16 @@ RUN export CMAKE_VERSION=3.17.1 && \
 ENV PATH=${INSTALL_DIR}/cmake/bin:$PATH
 
 # Install OpenMPI
-RUN export OPENMPI_VERSION=4.0.3 && \
+RUN export OPENMPI_VERSION=4.0.5 && \
     export OPENMPI_VERSION_SHORT=4.0 && \
-    export OPENMPI_SHA1=d958454e32da2c86dd32b7d557cf9a401f0a08d3 && \
+    export OPENMPI_SHA256=c58f3863b61d944231077f344fe6b4b8fbb83f3d1bc93ab74640bf3e5acac009 && \
     export OPENMPI_URL=https://www.open-mpi.org/software/ompi/v${OPENMPI_VERSION_SHORT}/downloads/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
     export OPENMPI_ARCHIVE=${ARCHIVE_DIR}/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
     export OPENMPI_SOURCE_DIR=${SOURCE_DIR}/openmpi && \
     export OPENMPI_BUILD_DIR=${BUILD_DIR}/openmpi && \
     export OPENMPI_INSTALL_DIR=${INSTALL_DIR}/openmpi && \
     wget --quiet ${OPENMPI_URL} --output-document=${OPENMPI_ARCHIVE} && \
-    echo "${OPENMPI_SHA1} ${OPENMPI_ARCHIVE}" | sha1sum -c && \
+    echo "${OPENMPI_SHA256} ${OPENMPI_ARCHIVE}" | sha256sum -c && \
     mkdir -p ${OPENMPI_SOURCE_DIR} && \
     tar -xf ${OPENMPI_ARCHIVE} -C ${OPENMPI_SOURCE_DIR} --strip-components=1 && \
     mkdir -p ${OPENMPI_BUILD_DIR} && \
@@ -74,10 +75,10 @@ ENV OMPI_MCA_btl_base_warn_component_unused='0'
 ENV PATH=${INSTALL_DIR}/openmpi/bin:$PATH
 
 # Install Boost
-RUN export BOOST_VERSION=1.72.0 && \
-    export BOOST_VERSION_U=1_72_0 && \
+RUN export BOOST_VERSION=1.73.0 && \
+    export BOOST_VERSION_U=1_73_0 && \
     export BOOST_URL=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_U}.tar.bz2 && \
-    export BOOST_SHA256=59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722 && \
+    export BOOST_SHA256=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402 && \
     export BOOST_ARCHIVE=${ARCHIVE_DIR}/boost_${BOOST_VERSION_U}.tar.bz2 && \
     export BOOST_SOURCE_DIR=${SOURCE_DIR}/boost && \
     export BOOST_BUILD_DIR=${BUILD_DIR}/boost && \
@@ -121,7 +122,7 @@ RUN export P4EST_VERSION=2.2 && \
 ENV P4EST_DIR=${INSTALL_DIR}/p4est
 
 # Install deal.II 
-RUN export DEAL_II_HASH=d782327269f81e7d4be3a32c4646f71d19804452 && \
+RUN export DEAL_II_HASH=551e93708c2f0b26f916795bd15f2f0e575e295c && \
     export DEAL_II_URL=https://github.com/Rombur/dealii/archive/${DEAL_II_HASH}.tar.gz && \
     export DEAL_II_ARCHIVE=${ARCHIVE_DIR}/dealii.tar.gz && \
     export DEAL_II_SOURCE_DIR=${SOURCE_DIR}/dealii && \
@@ -132,15 +133,16 @@ RUN export DEAL_II_HASH=d782327269f81e7d4be3a32c4646f71d19804452 && \
     tar -xf ${DEAL_II_ARCHIVE} -C ${DEAL_II_SOURCE_DIR} --strip-components=1 && \
     mkdir -p ${DEAL_II_BUILD_DIR} && cd ${DEAL_II_BUILD_DIR} && \
     cmake -DCMAKE_BUILD_TYPE=DebugRelease \
-        -DDEALII_WITH_64BIT_INDICES=ON \
+        -DCMAKE_CXX_FLAGS="-std=c++17" \
+        -DCMAKE_CUDA_FLAGS="-std=c++17" \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DDEAL_II_WITH_64BIT_INDICES=ON \
         -DDEAL_II_WITH_MPI=ON \
         -DDEAL_II_WITH_P4EST=ON \
         -DP4EST_DIR=${P4EST_DIR} \
-        -DDEAL_II_WITH_CXX14=ON \
-        -DDEAL_II_WITH_CXX17=OFF \
         -DDEAL_II_WITH_CUDA=ON \
         -DCMAKE_INSTALL_PREFIX=${DEAL_II_INSTALL_DIR} \
-        ${DEAL_II_SOURCE_DIR} && \
+        ${DEAL_II_SOURCE_DIR}  && \
     make -j${N_PROCS} install && \
     rm -rf ${DEAL_II_ARCHIVE} && \
     rm -rf ${DEAL_II_BUILD_DIR} && \

--- a/cmake/SetupTPLs.cmake
+++ b/cmake/SetupTPLs.cmake
@@ -12,10 +12,10 @@ set(Boost_COMPONENTS
     timer
     unit_test_framework
 )
-find_package(Boost 1.61.0 REQUIRED COMPONENTS ${Boost_COMPONENTS})
+find_package(Boost 1.70.0 REQUIRED COMPONENTS ${Boost_COMPONENTS})
 
 #### deal.II #################################################################
-find_package(deal.II 9.1 REQUIRED PATHS ${DEAL_II_DIR})
+find_package(deal.II 9.3 REQUIRED PATHS ${DEAL_II_DIR})
 
 # If deal.II was configured in DebugRelease mode, then if adamantine was configured
 # in Debug mode, we link against the Debug version of deal.II. If adamatine was

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -13,7 +13,7 @@ function(adamantine_ADD_BOOST_TEST TEST_NAME)
         target_compile_definitions(${TEST_NAME} PRIVATE ADAMANTINE_HAVE_CUDA)
     endif()
     set_target_properties(${TEST_NAME} PROPERTIES
-        CXX_STANDARD 14
+        CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
     )
@@ -46,11 +46,11 @@ function(adamantine_ADD_BOOST_CUDA_TEST TEST_NAME)
     target_link_libraries(${TEST_NAME} Adamantine)
     target_compile_definitions(${TEST_NAME} PRIVATE ADAMANTINE_HAVE_CUDA)
     set_target_properties(${TEST_NAME} PROPERTIES
-        CXX_STANDARD 14
+        CXX_STANDARD 17
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         CUDA_SEPARABLE_COMPILATION ON
-        CUDA_STANDARD 14
+        CUDA_STANDARD 17
         CUDA_STANDARD_REQUIRED ON
     )
     if(ARGN)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -52,7 +52,7 @@ add_library(Adamantine STATIC ${Adamantine_SOURCES})
 DEAL_II_SETUP_TARGET(Adamantine)
 
 set_target_properties(Adamantine PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )
@@ -60,7 +60,7 @@ set_target_properties(Adamantine PROPERTIES
 if (ADAMANTINE_ENABLE_CUDA)
 set_target_properties(Adamantine PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
-    CUDA_STANDARD 14
+    CUDA_STANDARD 17
     CUDA_STANDARD_REQUIRED ON
 )
 target_compile_definitions(Adamantine PRIVATE ADAMANTINE_HAVE_CUDA)

--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -240,7 +240,7 @@ inline double MaterialProperty<dim>::get_dof_index(
     typename dealii::Triangulation<dim>::active_cell_iterator const &cell) const
 {
   // Get a DoFCellAccessor from a Triangulation::active_cell_iterator.
-  dealii::DoFAccessor<dim, dealii::DoFHandler<dim>, false> dof_accessor(
+  dealii::DoFAccessor<dim, dim, dim, false> dof_accessor(
       &_mp_dof_handler.get_triangulation(), cell->level(), cell->index(),
       &_mp_dof_handler);
   std::vector<dealii::types::global_dof_index> mp_dof(1.);

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -32,18 +32,15 @@ public:
    */
   void reinit(dealii::DoFHandler<dim> const &dof_handler,
               dealii::AffineConstraints<double> const &affine_constraints,
-              dealii::QGaussLobatto<1> const &quad) override;
-
-  void reinit(dealii::DoFHandler<dim> const &dof_handler,
-              dealii::AffineConstraints<double> const &affine_constraints,
-              dealii::QGauss<1> const &quad) override;
+              dealii::hp::QCollection<1> const &quad) override;
 
   /**
    * Compute the inverse of the mass matrix and update the material properties.
    */
   void compute_inverse_mass_matrix(
       dealii::DoFHandler<dim> const &dof_handler,
-      dealii::AffineConstraints<double> const &affine_constraints) override;
+      dealii::AffineConstraints<double> const &affine_constraints,
+      dealii::hp::FECollection<dim> const &fe_collection) override;
 
   /**
    * Clear the MatrixFree object and resize the inverse of the mass matrix to

--- a/source/ThermalOperatorBase.hh
+++ b/source/ThermalOperatorBase.hh
@@ -10,8 +10,8 @@
 
 #include <Operator.hh>
 
-#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/dofs/dof_handler.h>
+#include <deal.II/hp/q_collection.h>
 #include <deal.II/lac/affine_constraints.h>
 
 namespace adamantine
@@ -24,20 +24,15 @@ public:
 
   virtual ~ThermalOperatorBase() = default;
 
-  // The function cannot be virtual and templated
   virtual void
   reinit(dealii::DoFHandler<dim> const &dof_handler,
          dealii::AffineConstraints<double> const &affine_constraints,
-         dealii::QGaussLobatto<1> const &quad) = 0;
-
-  virtual void
-  reinit(dealii::DoFHandler<dim> const &dof_handler,
-         dealii::AffineConstraints<double> const &affine_constraints,
-         dealii::QGauss<1> const &quad) = 0;
+         dealii::hp::QCollection<1> const &q_collection) = 0;
 
   virtual void compute_inverse_mass_matrix(
       dealii::DoFHandler<dim> const &dof_handler,
-      dealii::AffineConstraints<double> const &affine_constraints) = 0;
+      dealii::AffineConstraints<double> const &affine_constraints,
+      dealii::hp::FECollection<dim> const &fe_collection) = 0;
 
   virtual std::shared_ptr<
       dealii::LA::distributed::Vector<double, MemorySpaceType>>

--- a/source/ThermalOperatorDevice.hh
+++ b/source/ThermalOperatorDevice.hh
@@ -27,15 +27,12 @@ public:
 
   void reinit(dealii::DoFHandler<dim> const &dof_handler,
               dealii::AffineConstraints<double> const &affine_constraints,
-              dealii::QGaussLobatto<1> const &quad) override;
-
-  void reinit(dealii::DoFHandler<dim> const &dof_handler,
-              dealii::AffineConstraints<double> const &affine_constraints,
-              dealii::QGauss<1> const &quad) override;
+              dealii::hp::QCollection<1> const &q_collection) override;
 
   void compute_inverse_mass_matrix(
       dealii::DoFHandler<dim> const &dof_handler,
-      dealii::AffineConstraints<double> const &affine_constraints) override;
+      dealii::AffineConstraints<double> const &affine_constraints,
+      dealii::hp::FECollection<dim> const &fe_collection) override;
 
   void clear();
 

--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/time_stepping.h>
 #include <deal.II/base/time_stepping.templates.h>
-#include <deal.II/fe/fe_q.h>
+#include <deal.II/hp/fe_collection.h>
 
 #include <boost/property_tree/ptree.hpp>
 
@@ -157,7 +157,7 @@ private:
   /**
    * Associated Lagrange finite elements.
    */
-  dealii::FE_Q<dim> _fe;
+  dealii::hp::FECollection<dim> _fe_collection;
   /**
    * Associated DoFHandler.
    */
@@ -169,7 +169,7 @@ private:
   /**
    * Associated quadature, either Gauss or Gauss-Lobatto.
    */
-  QuadratureType _quadrature;
+  dealii::hp::QCollection<1> _q_collection;
   /**
    * Shared pointer to the material properties associated to the domain.
    */

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -12,6 +12,7 @@
 #include <PostProcessor.hh>
 #include <ThermalOperator.hh>
 
+#include <deal.II/fe/fe_nothing.h>
 #include <deal.II/fe/fe_q.h>
 
 #include <boost/filesystem.hpp>
@@ -31,12 +32,16 @@ BOOST_AUTO_TEST_CASE(post_processor)
   geometry_database.put("height_divisions", 5);
   adamantine::Geometry<2> geometry(communicator, geometry_database);
   // Create the DoFHandler
-  dealii::FE_Q<2> fe(2);
-  dealii::DoFHandler<2> dof_handler(geometry.get_triangulation());
-  dof_handler.distribute_dofs(fe);
+  dealii::hp::FECollection<2> fe_collection;
+  fe_collection.push_back(dealii::FE_Q<2>(2));
+  fe_collection.push_back(dealii::FE_Nothing<2>());
+  dealii::DoFHandler<2> dof_handler(geometry.get_triangulation(), true);
+  dof_handler.distribute_dofs(fe_collection);
   dealii::AffineConstraints<double> affine_constraints;
   affine_constraints.close();
-  dealii::QGauss<1> quad(3);
+  dealii::hp::QCollection<1> q_collection;
+  q_collection.push_back(dealii::QGauss<1>(3));
+  q_collection.push_back(dealii::QGauss<1>(1));
 
   // Create the MaterialProperty
   boost::property_tree::ptree mat_prop_database;
@@ -58,8 +63,9 @@ BOOST_AUTO_TEST_CASE(post_processor)
   // Initialize the ThermalOperator
   adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
       communicator, mat_properties);
-  thermal_operator.reinit(dof_handler, affine_constraints, quad);
-  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints);
+  thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
+  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
+                                               fe_collection);
 
   // Create the PostProcessor
   boost::property_tree::ptree post_processor_database;

--- a/tests/test_thermal_operator_device.cu
+++ b/tests/test_thermal_operator_device.cu
@@ -12,6 +12,7 @@
 #include <ThermalOperatorDevice.hh>
 
 #include <deal.II/dofs/dof_tools.h>
+#include <deal.II/fe/fe_nothing.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/read_write_vector.h>
@@ -35,12 +36,16 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev)
   geometry_database.put("height_divisions", 5);
   adamantine::Geometry<2> geometry(communicator, geometry_database);
   // Create the DoFHandler
-  dealii::FE_Q<2> fe(2);
-  dealii::DoFHandler<2> dof_handler(geometry.get_triangulation());
-  dof_handler.distribute_dofs(fe);
+  dealii::hp::FECollection<2> fe_collection;
+  fe_collection.push_back(dealii::FE_Q<2>(2));
+  fe_collection.push_back(dealii::FE_Nothing<2>());
+  dealii::DoFHandler<2> dof_handler(geometry.get_triangulation(), true);
+  dof_handler.distribute_dofs(fe_collection);
   dealii::AffineConstraints<double> affine_constraints;
   affine_constraints.close();
-  dealii::QGauss<1> quad(3);
+  dealii::hp::QCollection<1> q_collection;
+  q_collection.push_back(dealii::QGauss<1>(3));
+  q_collection.push_back(dealii::QGauss<1>(1));
 
   // Create the MaterialProperty
   boost::property_tree::ptree mat_prop_database;
@@ -62,9 +67,9 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev)
   // Initialize the ThermalOperator
   adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::CUDA>
       thermal_operator_dev(communicator, mat_properties);
-  thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
-                                                   affine_constraints);
-  thermal_operator_dev.reinit(dof_handler, affine_constraints, quad);
+  thermal_operator_dev.compute_inverse_mass_matrix(
+      dof_handler, affine_constraints, fe_collection);
+  thermal_operator_dev.reinit(dof_handler, affine_constraints, q_collection);
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> dummy(
       thermal_operator_dev.m());
   thermal_operator_dev.evaluate_material_properties(dummy);
@@ -113,12 +118,16 @@ BOOST_AUTO_TEST_CASE(spmv)
   geometry_database.put("height_divisions", 5);
   adamantine::Geometry<2> geometry(communicator, geometry_database);
   // Create the DoFHandler
-  dealii::FE_Q<2> fe(2);
-  dealii::DoFHandler<2> dof_handler(geometry.get_triangulation());
-  dof_handler.distribute_dofs(fe);
+  dealii::hp::FECollection<2> fe_collection;
+  fe_collection.push_back(dealii::FE_Q<2>(2));
+  fe_collection.push_back(dealii::FE_Nothing<2>());
+  dealii::DoFHandler<2> dof_handler(geometry.get_triangulation(), true);
+  dof_handler.distribute_dofs(fe_collection);
   dealii::AffineConstraints<double> affine_constraints;
   affine_constraints.close();
-  dealii::QGauss<1> quad(3);
+  dealii::hp::QCollection<1> q_collection;
+  q_collection.push_back(dealii::QGauss<1>(3));
+  q_collection.push_back(dealii::QGauss<1>(1));
 
   // Create the MaterialProperty
   boost::property_tree::ptree mat_prop_database;
@@ -140,9 +149,9 @@ BOOST_AUTO_TEST_CASE(spmv)
   // Initialize the ThermalOperator
   adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::CUDA>
       thermal_operator_dev(communicator, mat_properties);
-  thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
-                                                   affine_constraints);
-  thermal_operator_dev.reinit(dof_handler, affine_constraints, quad);
+  thermal_operator_dev.compute_inverse_mass_matrix(
+      dof_handler, affine_constraints, fe_collection);
+  thermal_operator_dev.reinit(dof_handler, affine_constraints, q_collection);
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> dummy(
       thermal_operator_dev.m());
   thermal_operator_dev.evaluate_material_properties(dummy);
@@ -204,12 +213,16 @@ BOOST_AUTO_TEST_CASE(mf_spmv)
   geometry_database.put("height_divisions", 5);
   adamantine::Geometry<2> geometry(communicator, geometry_database);
   // Create the DoFHandler
-  dealii::FE_Q<2> fe(2);
-  dealii::DoFHandler<2> dof_handler(geometry.get_triangulation());
-  dof_handler.distribute_dofs(fe);
+  dealii::hp::FECollection<2> fe_collection;
+  fe_collection.push_back(dealii::FE_Q<2>(2));
+  fe_collection.push_back(dealii::FE_Nothing<2>());
+  dealii::DoFHandler<2> dof_handler(geometry.get_triangulation(), true);
+  dof_handler.distribute_dofs(fe_collection);
   dealii::AffineConstraints<double> affine_constraints;
   affine_constraints.close();
-  dealii::QGauss<1> quad(3);
+  dealii::hp::QCollection<1> q_collection;
+  q_collection.push_back(dealii::QGauss<1>(3));
+  q_collection.push_back(dealii::QGauss<1>(1));
 
   // Create the MaterialProperty
   boost::property_tree::ptree mat_prop_database;
@@ -231,9 +244,9 @@ BOOST_AUTO_TEST_CASE(mf_spmv)
   // Initialize the ThermalOperator
   adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::CUDA>
       thermal_operator_dev(communicator, mat_properties);
-  thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
-                                                   affine_constraints);
-  thermal_operator_dev.reinit(dof_handler, affine_constraints, quad);
+  thermal_operator_dev.compute_inverse_mass_matrix(
+      dof_handler, affine_constraints, fe_collection);
+  thermal_operator_dev.reinit(dof_handler, affine_constraints, q_collection);
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> dummy(
       thermal_operator_dev.m());
   thermal_operator_dev.evaluate_material_properties(dummy);
@@ -242,9 +255,9 @@ BOOST_AUTO_TEST_CASE(mf_spmv)
 
   adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host>
       thermal_operator_host(communicator, mat_properties);
-  thermal_operator_host.compute_inverse_mass_matrix(dof_handler,
-                                                    affine_constraints);
-  thermal_operator_host.reinit(dof_handler, affine_constraints, quad);
+  thermal_operator_host.compute_inverse_mass_matrix(
+      dof_handler, affine_constraints, fe_collection);
+  thermal_operator_host.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator_host.evaluate_material_properties(dummy);
 
   // Compare vmult using matrix free and building the matrix

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -8,6 +8,8 @@
 #include <Geometry.hh>
 #include <ThermalPhysics.hh>
 
+#include <deal.II/base/quadrature_lib.h>
+
 template <typename MemorySpaceType>
 void thermal_2d(boost::property_tree::ptree &database, double time_step)
 {


### PR DESCRIPTION
This PR does the following:
 - Update the code to work with a newer version of deal.II: once this is merged everybody will need to update deal.II.
 - Update the build system: in particular require a newer version of CMake and bump the C++ standard to C++17. This will allow us to use the parallel capabilities of the STL library.
 - Use hp::FECollection everywhere this is needed for element activation.