### PR TITLE
Recompute the max height of the object during the simulation

### DIFF
--- a/source/CubeHeatSource.cc
+++ b/source/CubeHeatSource.cc
@@ -30,7 +30,8 @@ CubeHeatSource<dim>::CubeHeatSource(boost::property_tree::ptree const &database)
 
 template <int dim>
 double CubeHeatSource<dim>::value(dealii::Point<dim> const &point,
-                                  double const time) const
+                                  double const time,
+                                  double const /*height*/) const
 {
   if ((time > _start_time) && (time < _end_time))
   {

--- a/source/CubeHeatSource.hh
+++ b/source/CubeHeatSource.hh
@@ -38,8 +38,8 @@ public:
   /**
    * Return the value of the source for a given point and time.
    */
-  double value(dealii::Point<dim> const &point,
-               double const time) const override;
+  double value(dealii::Point<dim> const &point, double const time,
+               double const /*height*/) const override;
 
 private:
   double _start_time;

--- a/source/ElectronBeamHeatSource.cc
+++ b/source/ElectronBeamHeatSource.cc
@@ -13,18 +13,19 @@ namespace adamantine
 
 template <int dim>
 ElectronBeamHeatSource<dim>::ElectronBeamHeatSource(
-    boost::property_tree::ptree const &database, double max_height)
-    : HeatSource<dim>(database, max_height)
+    boost::property_tree::ptree const &database)
+    : HeatSource<dim>(database)
 {
 }
 
 template <int dim>
 double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point,
-                                          double const time) const
+                                          double const time,
+                                          double const height) const
 {
   // NOTE: Due to the differing coordinate systems, "z" here is the second
   // component of the input point.
-  double const z = point[1] - this->_max_height;
+  double const z = point[1] - height;
   if ((z + this->_beam.depth) < 0.)
   {
     return 0.;

--- a/source/ElectronBeamHeatSource.hh
+++ b/source/ElectronBeamHeatSource.hh
@@ -30,17 +30,15 @@ public:
    *   - <B>max_power</B>: double in \f$[0, \infty)\f$
    *   - <B>input_file</B>: name of the file that contains the scan path
    *     segments
-   * \param[in] max_height is the height of the domain
    */
-  ElectronBeamHeatSource(boost::property_tree::ptree const &database,
-                         double max_height);
+  ElectronBeamHeatSource(boost::property_tree::ptree const &database);
 
   /**
    * Returns the value of an electron beam heat source at a specified point and
    * time.
    */
-  double value(dealii::Point<dim> const &point,
-               double const time) const override;
+  double value(dealii::Point<dim> const &point, double const time,
+               double const height) const override;
 };
 } // namespace adamantine
 

--- a/source/Geometry.cc
+++ b/source/Geometry.cc
@@ -101,7 +101,6 @@ Geometry<dim>::Geometry(MPI_Comm const &communicator,
     dealii::Point<dim> p2;
     p2[0] = database.get<double>("length");
     p2[1] = database.get<double>("height");
-    _max_height = p2[1];
     if (dim == 3)
       p2[2] = database.get<double>("width");
 

--- a/source/Geometry.hh
+++ b/source/Geometry.hh
@@ -43,16 +43,7 @@ public:
    */
   dealii::parallel::distributed::Triangulation<dim> &get_triangulation();
 
-  /**
-   * Return the maximum height of the domain.
-   */
-  double get_max_height() const;
-
 private:
-  /**
-   * Maximum height of the domain.
-   */
-  double _max_height;
   /**
    * Shared pointer to the underlying Triangulation.
    */
@@ -64,12 +55,6 @@ private:
    */
   void assign_material_state(dealii::types::boundary_id top_boundary);
 };
-
-template <int dim>
-inline double Geometry<dim>::get_max_height() const
-{
-  return _max_height;
-}
 
 template <int dim>
 inline dealii::parallel::distributed::Triangulation<dim> &

--- a/source/GoldakHeatSource.cc
+++ b/source/GoldakHeatSource.cc
@@ -13,18 +13,19 @@ namespace adamantine
 
 template <int dim>
 GoldakHeatSource<dim>::GoldakHeatSource(
-    boost::property_tree::ptree const &database, double const max_height)
-    : HeatSource<dim>(database, max_height)
+    boost::property_tree::ptree const &database)
+    : HeatSource<dim>(database)
 {
 }
 
 template <int dim>
 double GoldakHeatSource<dim>::value(dealii::Point<dim> const &point,
-                                    double const time) const
+                                    double const time,
+                                    double const height) const
 {
   // NOTE: Due to the differing coordinate systems, "z" here is the second
   // component of the input point.
-  double const z = point[1] - this->_max_height;
+  double const z = point[1] - height;
   if ((z + this->_beam.depth) < 0.)
   {
     return 0.;

--- a/source/GoldakHeatSource.hh
+++ b/source/GoldakHeatSource.hh
@@ -30,16 +30,14 @@ public:
    *   - <B>max_power</B>: double in \f$[0, \infty)\f$
    *   - <B>input_file</B>: name of the file that contains the scan path
    *     segments
-   * \param[in] max_height is the height of the domain
    */
-  GoldakHeatSource(boost::property_tree::ptree const &database,
-                   double max_height);
+  GoldakHeatSource(boost::property_tree::ptree const &database);
 
   /**
    * Returns the value of a Goldak heat source at a specified point and time.
    */
-  double value(dealii::Point<dim> const &point,
-               double const time) const override;
+  double value(dealii::Point<dim> const &point, double const time,
+               double const height) const override;
 };
 } // namespace adamantine
 

--- a/source/HeatSource.hh
+++ b/source/HeatSource.hh
@@ -47,11 +47,9 @@ public:
    *   - <B>max_power</B>: double in \f$[0, \infty)\f$
    *   - <B>input_file</B>: name of the file that contains the scan path
    *     segments
-   * \param[in] max_height is the height of the domain
    */
-  HeatSource(boost::property_tree::ptree const &database,
-             double const max_height)
-      : _max_height(max_height), _beam(database),
+  HeatSource(boost::property_tree::ptree const &database)
+      : _beam(database),
         _scan_path(database.get<std::string>("scan_path_file"),
                    database.get<std::string>("scan_path_file_format"))
   {
@@ -63,17 +61,13 @@ public:
   virtual ~HeatSource() = default;
 
   /**
-   * Compute the heat source at a given point at a given time.
+   * Compute the heat source at a given point at a given time given the current
+   * height of the object being manufactured.
    */
-  virtual double value(dealii::Point<dim> const &point,
-                       double const time) const = 0;
+  virtual double value(dealii::Point<dim> const &point, double const time,
+                       double const height) const = 0;
 
 protected:
-  /**
-   * Height of the domain.
-   */
-  double _max_height = 0.;
-
   /**
    * Structure of the physical properties of the beam heat source.
    */

--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -103,6 +103,11 @@ public:
    */
   std::vector<std::unique_ptr<HeatSource<dim>>> &get_heat_sources();
 
+  /**
+   * Return the current height of the object.
+   */
+  double get_current_height() const;
+
 private:
   using LA_Vector =
       typename dealii::LA::distributed::Vector<double, MemorySpaceType>;
@@ -123,11 +128,11 @@ private:
   /**
    * This flag is true if the time stepping method is embedded.
    */
-  bool _embedded_method;
+  bool _embedded_method = false;
   /**
    * This flag is true if the time stepping method is implicit.
    */
-  bool _implicit_method;
+  bool _implicit_method = false;
   /**
    * This flag is true if right preconditioning is used to invert the
    * ImplicitOperator.
@@ -149,6 +154,10 @@ private:
    * Tolerance to inverte the ImplicitOperator.
    */
   double _tolerance;
+  /**
+   * Current height of the object.
+   */
+  double _current_height = 0.;
   /**
    * Associated geometry.
    */
@@ -235,6 +244,14 @@ ThermalPhysics<dim, fe_degree, MemorySpaceType,
                QuadratureType>::get_heat_sources()
 {
   return _heat_sources;
+}
+
+template <int dim, int fe_degree, typename MemorySpaceType,
+          typename QuadratureType>
+inline double ThermalPhysics<dim, fe_degree, MemorySpaceType,
+                             QuadratureType>::get_current_height() const
+{
+  return _current_height;
 }
 } // namespace adamantine
 

--- a/tests/test_heat_source.cc
+++ b/tests/test_heat_source.cc
@@ -29,38 +29,38 @@ BOOST_AUTO_TEST_CASE(heat_source_value_2d)
   database.put("max_power", 10.);
   database.put("scan_path_file", "scan_path.txt");
   database.put("scan_path_file_format", "segment");
-  GoldakHeatSource<2> goldak_heat_source(database, 0.2);
-  ElectronBeamHeatSource<2> eb_heat_source(database, 0.2);
+  GoldakHeatSource<2> goldak_heat_source(database);
+  ElectronBeamHeatSource<2> eb_heat_source(database);
 
   double g_value = 0.0;
   double eb_value = 0.0;
 
   std::cout << "Checking point 1..." << std::endl;
   dealii::Point<2> point1(0.0, 0.15);
-  g_value = goldak_heat_source.value(point1, 1.0e-7);
+  g_value = goldak_heat_source.value(point1, 1.0e-7, 0.2);
   BOOST_CHECK_CLOSE(g_value, 0.0, tolerance);
 
-  eb_value = eb_heat_source.value(point1, 1.0e-7);
+  eb_value = eb_heat_source.value(point1, 1.0e-7, 0.2);
   BOOST_CHECK_CLOSE(eb_value, 0.0, tolerance);
 
   std::cout << "Checking point 2..." << std::endl;
   dealii::Point<2> point2(10.0, 0.0);
-  g_value = goldak_heat_source.value(point2, 5.0e-7);
+  g_value = goldak_heat_source.value(point2, 5.0e-7, 0.2);
   BOOST_CHECK_CLOSE(g_value, 0.0, tolerance);
 
-  eb_value = eb_heat_source.value(point2, 5.0e-7);
+  eb_value = eb_heat_source.value(point2, 5.0e-7, 0.2);
   BOOST_CHECK_CLOSE(eb_value, 0.0, tolerance);
 
   // Check the beam center 0.001 s into the second segment
   std::cout << "Checking point 3..." << std::endl;
   dealii::Point<2> point3(8.0e-4, 0.2);
-  g_value = goldak_heat_source.value(point3, 0.001001);
+  g_value = goldak_heat_source.value(point3, 0.001001, 0.2);
   double pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
   double expected_value =
       2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
   BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
 
-  eb_value = eb_heat_source.value(point3, 0.001001);
+  eb_value = eb_heat_source.value(point3, 0.001001, 0.2);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) * 1. * 1.;
   BOOST_CHECK_CLOSE(eb_value, expected_value, tolerance);
@@ -68,13 +68,13 @@ BOOST_AUTO_TEST_CASE(heat_source_value_2d)
   // Check slightly off beam center 0.001 s into the second segment
   std::cout << "Checking point 4..." << std::endl;
   dealii::Point<2> point4(7.0e-4, 0.19);
-  g_value = goldak_heat_source.value(point4, 0.001001);
+  g_value = goldak_heat_source.value(point4, 0.001001, 0.2);
   expected_value = 2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
   expected_value *=
       std::exp(-3.0 * 1.0e-4 * 1.0e-4 / 0.25 - 3.0 * 0.01 * 0.01 / 0.1 / 0.1);
   BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
 
-  eb_value = eb_heat_source.value(point4, 0.001001);
+  eb_value = eb_heat_source.value(point4, 0.001001, 0.2);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) *
                    std::exp(std::log(0.1) * 1.0e-4 * 1.0e-4 / 0.25) *
@@ -95,37 +95,37 @@ BOOST_AUTO_TEST_CASE(heat_source_value_3d)
   database.put("scan_path_file", "scan_path.txt");
   database.put("scan_path_file_format", "segment");
 
-  GoldakHeatSource<3> goldak_heat_source(database, 0.2);
-  ElectronBeamHeatSource<3> eb_heat_source(database, 0.2);
+  GoldakHeatSource<3> goldak_heat_source(database);
+  ElectronBeamHeatSource<3> eb_heat_source(database);
 
   double g_value = 0.0;
   double eb_value = 0.0;
 
   std::cout << "Checking point 1..." << std::endl;
   dealii::Point<3> point1(0.0, 0.15, 0.0);
-  g_value = goldak_heat_source.value(point1, 1.0e-7);
+  g_value = goldak_heat_source.value(point1, 1.0e-7, 0.2);
   BOOST_CHECK_CLOSE(g_value, 0.0, tolerance);
 
-  eb_value = eb_heat_source.value(point1, 1.0e-7);
+  eb_value = eb_heat_source.value(point1, 1.0e-7, 0.2);
   BOOST_CHECK_CLOSE(eb_value, 0.0, tolerance);
 
   std::cout << "Checking point 2..." << std::endl;
   dealii::Point<3> point2(10.0, 0.0, 0.0);
-  g_value = goldak_heat_source.value(point2, 5.0e-7);
+  g_value = goldak_heat_source.value(point2, 5.0e-7, 0.2);
   BOOST_CHECK_CLOSE(g_value, 0.0, tolerance);
 
-  eb_value = eb_heat_source.value(point2, 5.0e-7);
+  eb_value = eb_heat_source.value(point2, 5.0e-7, 0.2);
   BOOST_CHECK_CLOSE(eb_value, 0.0, tolerance);
 
   // Check the beam center 0.001 s into the second segment
   std::cout << "Checking point 3..." << std::endl;
   dealii::Point<3> point3(8e-4, 0.2, 0.0);
-  g_value = goldak_heat_source.value(point3, 0.001001);
+  g_value = goldak_heat_source.value(point3, 0.001001, 0.2);
   double pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
   double expected_value = 2.0 * 0.1 * 10.0 / 0.5 / 0.5 / 0.1 / pi_over_3_to_1p5;
   BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
 
-  eb_value = eb_heat_source.value(point3, 0.001001);
+  eb_value = eb_heat_source.value(point3, 0.001001, 0.2);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) * 1. * 1.;
   BOOST_CHECK_CLOSE(eb_value, expected_value, tolerance);
@@ -133,13 +133,13 @@ BOOST_AUTO_TEST_CASE(heat_source_value_3d)
   // Check slightly off beam center 0.001 s into the second segment
   std::cout << "Checking point 4..." << std::endl;
   dealii::Point<3> point4(7.0e-4, 0.19, 0.0);
-  g_value = goldak_heat_source.value(point4, 0.001001);
+  g_value = goldak_heat_source.value(point4, 0.001001, 0.2);
   expected_value = 2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
   expected_value *=
       std::exp(-3.0 * 1.0e-4 * 1.0e-4 / 0.25 - 3.0 * 0.01 * 0.01 / 0.1 / 0.1);
   BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
 
-  eb_value = eb_heat_source.value(point4, 0.001001);
+  eb_value = eb_heat_source.value(point4, 0.001001, 0.2);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) *
                    std::exp(std::log(0.1) * 1.0e-4 * 1.0e-4 / 0.25) *


### PR DESCRIPTION
This allows the heat sources to adapt to the addition of material. This is PR uses a single new height. This is sufficient for now and I am not sure that we are interested in cases where the new height is different in different part of the domain. That would mean that we start building part of the object and then go back down to finish another part.