### PR TITLE
Create map between x, y, and z axes and 0, 1, and 2 indices

### DIFF
--- a/source/ElectronBeamHeatSource.cc
+++ b/source/ElectronBeamHeatSource.cc
@@ -7,6 +7,7 @@
 
 #include <ElectronBeamHeatSource.hh>
 #include <instantiation.hh>
+#include <types.hh>
 
 namespace adamantine
 {
@@ -23,9 +24,7 @@ double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point,
                                           double const time,
                                           double const height) const
 {
-  // NOTE: Due to the differing coordinate systems, "z" here is the second
-  // component of the input point.
-  double const z = point[1] - height;
+  double const z = point[axis<dim>::z] - height;
   if ((z + this->_beam.depth) < 0.)
   {
     return 0.;
@@ -36,12 +35,12 @@ double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point,
                                   2. * (z / this->_beam.depth) + 1.;
 
     dealii::Point<3> const beam_center = this->_scan_path.value(time);
-    double xpy_squared = std::pow(point[0] - beam_center[0], 2);
+    double xpy_squared =
+        std::pow(point[axis<dim>::x] - beam_center[axis<dim>::x], 2);
     if (dim == 3)
     {
-      // NOTE: Due to the differing coordinate systems, "y" here is the third
-      // component of the input point.
-      xpy_squared += std::pow(point[2] - beam_center[1], 2);
+      xpy_squared +=
+          std::pow(point[axis<dim>::y] - beam_center[axis<dim>::y], 2);
     }
     double segment_power_modifier = this->_scan_path.get_power_modifier(time);
 

--- a/source/Geometry.cc
+++ b/source/Geometry.cc
@@ -99,22 +99,22 @@ Geometry<dim>::Geometry(MPI_Comm const &communicator,
   {
     std::vector<unsigned int> repetitions(dim);
     // PropertyTreeInput geometry.length_divisions
-    repetitions[0] = database.get("length_divisions", 10);
+    repetitions[axis<dim>::x] = database.get("length_divisions", 10);
     // PropertyTreeInput geometry.height_divisions
-    repetitions[1] = database.get("height_divisions", 10);
+    repetitions[axis<dim>::z] = database.get("height_divisions", 10);
     // PropertyTreeInput geometry.width_divisions
     if (dim == 3)
-      repetitions[2] = database.get("width_divisions", 10);
+      repetitions[axis<dim>::y] = database.get("width_divisions", 10);
 
     dealii::Point<dim> p1;
     dealii::Point<dim> p2;
     // PropertyTreeInput geometry.length
-    p2[0] = database.get<double>("length");
+    p2[axis<dim>::x] = database.get<double>("length");
     // PropertyTreeInput geometry.height
-    p2[1] = database.get<double>("height");
+    p2[axis<dim>::z] = database.get<double>("height");
     // PropertyTreeInput geometry.width
     if (dim == 3)
-      p2[2] = database.get<double>("width");
+      p2[axis<dim>::y] = database.get<double>("width");
 
     // For now we assume that the geometry is very simple.
     dealii::GridGenerator::subdivided_hyper_rectangle(
@@ -127,7 +127,7 @@ Geometry<dim>::Geometry(MPI_Comm const &communicator,
     }
 
     // Assign the MaterialState.
-    dealii::types::boundary_id const top_boundary = 3;
+    dealii::types::boundary_id const top_boundary = (dim == 2) ? 3 : 5;
     assign_material_state(top_boundary);
   }
 }

--- a/source/GoldakHeatSource.cc
+++ b/source/GoldakHeatSource.cc
@@ -7,6 +7,7 @@
 
 #include <GoldakHeatSource.hh>
 #include <instantiation.hh>
+#include <types.hh>
 
 namespace adamantine
 {
@@ -23,9 +24,7 @@ double GoldakHeatSource<dim>::value(dealii::Point<dim> const &point,
                                     double const time,
                                     double const height) const
 {
-  // NOTE: Due to the differing coordinate systems, "z" here is the second
-  // component of the input point.
-  double const z = point[1] - height;
+  double const z = point[axis<dim>::z] - height;
   if ((z + this->_beam.depth) < 0.)
   {
     return 0.;
@@ -33,12 +32,12 @@ double GoldakHeatSource<dim>::value(dealii::Point<dim> const &point,
   else
   {
     dealii::Point<3> const beam_center = this->_scan_path.value(time);
-    double xpy_squared = std::pow(point[0] - beam_center[0], 2);
+    double xpy_squared =
+        std::pow(point[axis<dim>::x] - beam_center[axis<dim>::x], 2);
     if (dim == 3)
     {
-      // NOTE: Due to the differing coordinate systems, "y" here is the third
-      // component of the input point.
-      xpy_squared += std::pow(point[2] - beam_center[1], 2);
+      xpy_squared +=
+          std::pow(point[axis<dim>::y] - beam_center[axis<dim>::y], 2);
     }
     double segment_power_modifier = this->_scan_path.get_power_modifier(time);
     double pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);

--- a/source/types.hh
+++ b/source/types.hh
@@ -70,6 +70,32 @@ enum Timing
   evol_time_J_inv,
   evol_time_eval_mat_prop
 };
+
+/**
+ * This structure provides a mapping between the axes x, y, and z and the
+ * indices 0, 1, and 2. In 2D, the valid axes are x and z while in 3D x, y, and
+ * z are valid.
+ */
+template <int dim>
+struct axis;
+
+// dim == 2 specialization
+template <>
+struct axis<2>
+{
+  static int constexpr x = 0;
+  static int constexpr y = -1;
+  static int constexpr z = 1;
+};
+
+// dim == 3 specialization
+template <>
+struct axis<3>
+{
+  static int constexpr x = 0;
+  static int constexpr y = 1;
+  static int constexpr z = 2;
+};
 } // namespace adamantine
 
 #endif

--- a/tests/test_geometry.cc
+++ b/tests/test_geometry.cc
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(geometry_3D)
 
   BOOST_CHECK(tria.n_active_cells() == 40);
 
-  dealii::types::boundary_id const top_boundary = 3;
+  dealii::types::boundary_id const top_boundary = 5;
   check_material_id(tria, top_boundary);
 }
 

--- a/tests/test_heat_source.cc
+++ b/tests/test_heat_source.cc
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(heat_source_value_3d)
   double eb_value = 0.0;
 
   std::cout << "Checking point 1..." << std::endl;
-  dealii::Point<3> point1(0.0, 0.15, 0.0);
+  dealii::Point<3> point1(0.0, 0.0, 0.15);
   g_value = goldak_heat_source.value(point1, 1.0e-7, 0.2);
   BOOST_CHECK_CLOSE(g_value, 0.0, tolerance);
 
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(heat_source_value_3d)
 
   // Check the beam center 0.001 s into the second segment
   std::cout << "Checking point 3..." << std::endl;
-  dealii::Point<3> point3(8e-4, 0.2, 0.0);
+  dealii::Point<3> point3(8e-4, 0.0, 0.2);
   g_value = goldak_heat_source.value(point3, 0.001001, 0.2);
   double pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
   double expected_value = 2.0 * 0.1 * 10.0 / 0.5 / 0.5 / 0.1 / pi_over_3_to_1p5;
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(heat_source_value_3d)
 
   // Check slightly off beam center 0.001 s into the second segment
   std::cout << "Checking point 4..." << std::endl;
-  dealii::Point<3> point4(7.0e-4, 0.19, 0.0);
+  dealii::Point<3> point4(7.0e-4, 0.0, 0.19);
   g_value = goldak_heat_source.value(point4, 0.001001, 0.2);
   expected_value = 2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
   expected_value *=


### PR DESCRIPTION
The element activation code has many moving parts so instead of having one big PR, I will create a bunch of small ones. This PR fixes the problem where the y and z are switched in 3D