### PR TITLE
Fix bugs when using more than one MPI rank

### DIFF
--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -397,10 +397,11 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
   {
     val = std::numeric_limits<double>::infinity();
   }
+  solution.update_ghost_values();
   std::vector<dealii::types::global_dof_index> dof_indices(dofs_per_cell);
-  for (auto cell : _dof_handler.active_cell_iterators())
+  for (auto const &cell : _dof_handler.active_cell_iterators())
   {
-    if (cell->active_fe_index() == 0)
+    if ((cell->is_locally_owned()) && (cell->active_fe_index() == 0))
     {
       cell->get_dof_values(solution, cell_solution);
       data_to_transfer.push_back(cell_solution);
@@ -444,7 +445,8 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
   unsigned int cell_i = 0;
   for (auto const &cell : _dof_handler.active_cell_iterators())
   {
-    if (transferred_data[cell_i][0] != std::numeric_limits<double>::infinity())
+    if ((cell->is_locally_owned()) && (transferred_data[cell_i][0] !=
+                                       std::numeric_limits<double>::infinity()))
     {
       cell->set_dof_values(transferred_data[cell_i], solution);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,8 +10,6 @@ list(APPEND
      test_geometry
      test_heat_source
      test_implicit_operator
-     test_integration_2d
-     test_material_deposition
      test_material_property
      test_newton_solver
      test_post_processor
@@ -24,6 +22,8 @@ list(APPEND
 set(MPI_UNIT_TESTS "")
 list(APPEND
      MPI_UNIT_TESTS
+     test_integration_2d
+     test_material_deposition
      test_thermal_physics
     )
 


### PR DESCRIPTION
Transferring solution when adding material is a little bit tricky. First, I forgot to update the ghost value. Second to use `CellDataTransfer`, we need data on every active including non-locally owned. So we need to be very careful on which operation is done on locally owned cells and which operation is done on active cells.