### PR TITLE
Replace Boost assert with cassert

### DIFF
--- a/cmake/Setupadamantine.cmake
+++ b/cmake/Setupadamantine.cmake
@@ -1,10 +1,4 @@
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
-if(CMAKE_BUILD_TYPE MATCHES "Release")
-  add_definitions(-DBOOST_DISABLE_ASSERTS)
-elseif(CMAKE_BUILD_TYPE MATCHES "Debug")
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
   add_definitions(-DADAMANTINE_DEBUG)
-else()
-  message(SEND_ERROR
-        "Possible values for CMAKE_BUILD_TYPE are Debug and Release"
-    )
 endif()

--- a/source/utils.hh
+++ b/source/utils.hh
@@ -8,8 +8,7 @@
 #ifndef UTILS_HH
 #define UTILS_HH
 
-#include <boost/assert.hpp>
-
+#include <cassert>
 #include <exception>
 #include <stdexcept>
 #include <string>
@@ -19,7 +18,7 @@ namespace adamantine
 
 inline void ASSERT(bool cond, std::string const &message)
 {
-  BOOST_ASSERT_MSG(cond, message.c_str());
+  assert((cond) && (message.c_str()));
   (void)cond;
   (void)message;
 }


### PR DESCRIPTION
I had a plan to use a more advanced `assert` from boost but I don't think that's worth the effort. Instead, let's just use `cassert` this slightly simplifies the build system.