### PR TITLE
improve scan path robustness

### DIFF
--- a/source/ScanPath.cc
+++ b/source/ScanPath.cc
@@ -164,6 +164,16 @@ void ScanPath::update_current_segment_info(
 
 dealii::Point<3> ScanPath::value(double const &time) const
 {
+  // If the current time is after the scan path data is over, return a point
+  // that is (presumably) out of the domain.
+  if (time > _segment_list.back().end_time)
+  {
+    dealii::Point<3> out_of_domain_point(std::numeric_limits<double>::max(),
+                                         std::numeric_limits<double>::max(),
+                                         std::numeric_limits<double>::max());
+    return out_of_domain_point;
+  }
+
   // Get to the correct segment (assumes that the current time is never
   // before the current segment starts)
   dealii::Point<3> segment_start_point;
@@ -177,32 +187,23 @@ dealii::Point<3> ScanPath::value(double const &time) const
           (_segment_list[_current_segment].end_time - segment_start_time) *
           (time - segment_start_time);
 
-  if (time <= _segment_list.back().end_time)
-  {
-    return position;
-  }
-  else
-  {
-    return _segment_list.back().end_point;
-  }
+  return position;
 }
 
 double ScanPath::get_power_modifier(double const &time) const
 {
+  // If the current time is after the scan path data is over, set the power to
+  // zero.
+  if (time > _segment_list.back().end_time)
+    return 0.0;
+
   // Get to the correct segment (assumes that the current time is never
   // before the current segment starts)
   dealii::Point<3> segment_start_point;
   double segment_start_time = 0.0;
   update_current_segment_info(time, segment_start_point, segment_start_time);
 
-  if (time <= _segment_list.back().end_time)
-  {
-    return _segment_list[_current_segment].power_modifier;
-  }
-  else
-  {
-    return 0.0;
-  }
+  return _segment_list[_current_segment].power_modifier;
 }
 
 } // namespace adamantine

--- a/source/ScanPath.cc
+++ b/source/ScanPath.cc
@@ -177,7 +177,14 @@ dealii::Point<3> ScanPath::value(double const &time) const
           (_segment_list[_current_segment].end_time - segment_start_time) *
           (time - segment_start_time);
 
-  return position;
+  if (time <= _segment_list.back().end_time)
+  {
+    return position;
+  }
+  else
+  {
+    return _segment_list.back().end_point;
+  }
 }
 
 double ScanPath::get_power_modifier(double const &time) const
@@ -188,7 +195,14 @@ double ScanPath::get_power_modifier(double const &time) const
   double segment_start_time = 0.0;
   update_current_segment_info(time, segment_start_point, segment_start_time);
 
-  return _segment_list[_current_segment].power_modifier;
+  if (time <= _segment_list.back().end_time)
+  {
+    return _segment_list[_current_segment].power_modifier;
+  }
+  else
+  {
+    return 0.0;
+  }
 }
 
 } // namespace adamantine

--- a/tests/test_heat_source.cc
+++ b/tests/test_heat_source.cc
@@ -80,6 +80,15 @@ BOOST_AUTO_TEST_CASE(heat_source_value_2d)
                    std::exp(std::log(0.1) * 1.0e-4 * 1.0e-4 / 0.25) *
                    (-3.0 * 0.01 * 0.01 / 0.1 / 0.1 + 2.0 * 0.01 / 0.1 + 1.0);
   BOOST_CHECK_CLOSE(eb_value, expected_value, tolerance);
+
+  // Checking beyond the defined time, where the expected value is zero
+  std::cout << "Checking point 5..." << std::endl;
+  g_value = goldak_heat_source.value(point4, 100.0, 0.2);
+  expected_value = 0.0;
+  BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
+
+  eb_value = eb_heat_source.value(point4, 100.0, 0.2);
+  BOOST_CHECK_CLOSE(eb_value, expected_value, tolerance);
 }
 
 BOOST_AUTO_TEST_CASE(heat_source_value_3d)

--- a/tests/test_scan_path.cc
+++ b/tests/test_scan_path.cc
@@ -96,6 +96,14 @@ BOOST_AUTO_TEST_CASE(scan_path_location)
   BOOST_CHECK_CLOSE(p2[0], 8.0e-4, tolerance);
   BOOST_CHECK_CLOSE(p2[1], 0.0, tolerance);
   BOOST_CHECK_CLOSE(p2[2], 0.0, tolerance);
+
+  time = 100.0;
+  dealii::Point<3> p3 = scan_path.value(time);
+  BOOST_CHECK_CLOSE(p3[0], 0.002, tolerance);
+  BOOST_CHECK_CLOSE(p3[1], 0.0, tolerance);
+  BOOST_CHECK_CLOSE(p3[2], 0.0, tolerance);
+  double power = scan_path.get_power_modifier(time);
+  BOOST_CHECK_CLOSE(power, 0.0, tolerance);
 }
 
 } // namespace adamantine

--- a/tests/test_scan_path.cc
+++ b/tests/test_scan_path.cc
@@ -99,9 +99,9 @@ BOOST_AUTO_TEST_CASE(scan_path_location)
 
   time = 100.0;
   dealii::Point<3> p3 = scan_path.value(time);
-  BOOST_CHECK_CLOSE(p3[0], 0.002, tolerance);
-  BOOST_CHECK_CLOSE(p3[1], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(p3[2], 0.0, tolerance);
+  BOOST_CHECK_CLOSE(p3[0], std::numeric_limits<double>::max(), tolerance);
+  BOOST_CHECK_CLOSE(p3[1], std::numeric_limits<double>::max(), tolerance);
+  BOOST_CHECK_CLOSE(p3[2], std::numeric_limits<double>::max(), tolerance);
   double power = scan_path.get_power_modifier(time);
   BOOST_CHECK_CLOSE(power, 0.0, tolerance);
 }


### PR DESCRIPTION
When the simulation reaches the end of a scan path file, the heat source power is now set to zero and its position is the last position from the scan path file. Previously there could be unexpected behavior.